### PR TITLE
Add @font-face declarations using 'BC Sans' for font-family

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,34 @@ If you are wanting the fonts in different file formats, here are all the options
 #### React
 
 Embed into a root level component
-`import '@bcgov/bc-sans/css/BCSans.css'`
+`import '@bcgov/bc-sans/css/BC_Sans.css'`
 
 #### Typography.js
 >See Typography.js installation instructions [here](https://github.com/KyleAMathews/typography.js)
 ```js
 import Typography from 'typography';
-import '@bcgov/bc-sans/css/BCSans.css';
+import '@bcgov/bc-sans/css/BC_Sans.css';
 
 const typography = new Typography({
   baseFontSize: '16px',
   baseLineHeight: 1.25,
-  headerFontFamily: ['BCSans', 'Noto Sans', 'Verdana', 'Arial', 'sans-serif'],
-  bodyFontFamily: ['BCSans', 'Noto Sans', 'Verdana', 'Arial', 'sans-serif'],
+  headerFontFamily: ['BC Sans', 'Noto Sans', 'Verdana', 'Arial', 'sans-serif'],
+  bodyFontFamily: ['BC Sans', 'Noto Sans', 'Verdana', 'Arial', 'sans-serif'],
   scaleRatio: 2.074,
 });
 
 export default typography;
 ```
+
+### Why are there two similar CSS files in this package?
+
+For new projects, you only need to include one of the two CSS files: `css/BC_Sans.css`. Then, reference `BC Sans` in your CSS `font-family` rules.
+
+Originally, this package shipped with just `css/BCSans.css`. This file uses `BCSans` (no space) as the `font-family` name in its `@font-face` declarations. Lots of existing application code references this name. But the metadata in the font files use `BC Sans` (with a space) for the font family name. As a result, UI design tools like Figma output code using `BC Sans` from the font files. This generated code would not work directly with this package without manual intervention.
+
+`css/BC_Sans.css` uses `BC Sans` for its CSS `font-family` names. This matches the family metadata fields in the font files. Font style code generated from Figma works with `css/BC_Sans.css`. New projects should use `css/BC_Sans.css` for smoothest designer to developer hand-off. For existing projects, there is no need to switch.
+
+### Contributing
 
 Integrating it differently? [Create a pull request](https://github.com/bcgov/bc-sans/pulls) to help us build out the documentation.
 

--- a/css/BCSans.css
+++ b/css/BCSans.css
@@ -45,3 +45,51 @@
   src: url("../fonts/BCSans-LightItalic.woff2") format("woff2"),
        url("../fonts/BCSans-LightItalic.woff") format("woff");
 }
+
+@font-face {
+  font-family: "BC Sans";
+  font-style: normal;
+  font-weight: 400;
+  src: url("../fonts/BCSans-Regular.woff2") format("woff2"),
+       url("../fonts/BCSans-Regular.woff") format("woff");
+}
+
+@font-face {
+  font-family: "BC Sans";
+  font-style: italic;
+  font-weight: 400;
+  src: url("../fonts/BCSans-Italic.woff2") format("woff2"),
+       url("../fonts/BCSans-Italic.woff") format("woff");
+}
+
+@font-face {
+  font-family: "BC Sans";
+  font-style: normal;
+  font-weight: 700;
+  src: url("../fonts/BCSans-Bold.woff2") format("woff2"),
+       url("../fonts/BCSans-Bold.woff") format("woff");
+}
+
+@font-face {
+  font-family: "BC Sans";
+  font-style: italic;
+  font-weight: 700;
+  src: url("../fonts/BCSans-BoldItalic.woff2") format("woff2"),
+       url("../fonts/BCSans-BoldItalic.woff") format("woff");
+}
+
+@font-face {
+  font-family: "BC Sans";
+  font-style: normal;
+  font-weight: 300;
+  src: url("../fonts/BCSans-Light.woff2") format("woff2"),
+       url("../fonts/BCSans-Light.woff") format("woff");
+}
+
+@font-face {
+  font-family: "BC Sans";
+  font-style: italic;
+  font-weight: 300;
+  src: url("../fonts/BCSans-LightItalic.woff2") format("woff2"),
+       url("../fonts/BCSans-LightItalic.woff") format("woff");
+}

--- a/css/BC_Sans.css
+++ b/css/BC_Sans.css
@@ -1,5 +1,5 @@
 @font-face {
-  font-family: "BCSans";
+  font-family: "BC Sans";
   font-style: normal;
   font-weight: 400;
   src: url("../fonts/BCSans-Regular.woff2") format("woff2"),
@@ -7,7 +7,7 @@
 }
 
 @font-face {
-  font-family: "BCSans";
+  font-family: "BC Sans";
   font-style: italic;
   font-weight: 400;
   src: url("../fonts/BCSans-Italic.woff2") format("woff2"),
@@ -15,7 +15,7 @@
 }
 
 @font-face {
-  font-family: "BCSans";
+  font-family: "BC Sans";
   font-style: normal;
   font-weight: 700;
   src: url("../fonts/BCSans-Bold.woff2") format("woff2"),
@@ -23,7 +23,7 @@
 }
 
 @font-face {
-  font-family: "BCSans";
+  font-family: "BC Sans";
   font-style: italic;
   font-weight: 700;
   src: url("../fonts/BCSans-BoldItalic.woff2") format("woff2"),
@@ -31,7 +31,7 @@
 }
 
 @font-face {
-  font-family: "BCSans";
+  font-family: "BC Sans";
   font-style: normal;
   font-weight: 300;
   src: url("../fonts/BCSans-Light.woff2") format("woff2"),
@@ -39,7 +39,7 @@
 }
 
 @font-face {
-  font-family: "BCSans";
+  font-family: "BC Sans";
   font-style: italic;
   font-weight: 300;
   src: url("../fonts/BCSans-LightItalic.woff2") format("woff2"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/bc-sans",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The standard font for B.C. Government digital services is BC Sans. BC Sans is an open source font family, and is a modified version of Noto Sans, developed by Google. BC Sans includes modifications to support Indigenous languages in British Columbia.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I'm making this PR for discussion - there might be a better way to solve this that I'm missing.

The CSS file that ships with this package [has always used](https://github.com/bcgov/bc-sans/commit/60b44c6a657f6d3f42bbb860b24e4faa75a449b0#diff-eb5f4417c8e7f8b9629ada675cbd1fe9116fe3fa72142fca68a156eaf1624f33) `BCSans` (no space) for the `font-family` value inside its `@font-face` declarations. By contrast, the metadata in the font files use `BC Sans` (with a space) for the font family name.

Here's an example of the metadata for the WOFF file for BC Sans Regular in a Font Forge window:

<img width="887" alt="Font Forge windows showing BC Sans font family name" src="https://github.com/bcgov/bc-sans/assets/25143706/3568126e-22ca-4f1f-8f72-c814ee6b1546">

We (OSS Design Team in GDX) have begun work on a new version of the [BC Design System](https://developer.gov.bc.ca/Design-System/About-the-Design-System) where we will be shipping a Figma design system file and a [design tokens package](https://www.npmjs.com/package/@bcgov/design-tokens) for use by designers and developers. Figma alows for designers to design using custom fonts like BC Sans, either through its desktop app directly, or through its web interface using a [separate desktop font integration app](https://www.figma.com/downloads/). Since the BC Sans font files use the name `BC Sans` with a space, all designs that reference the font end up using the name with the space in the code samples generated by Figma. Because of this, if I want to allow our @bcgov/design-tokens package to work with the CSS provided by this package, I would need to manually update the name of the font-family in the design tokens variables.

Example design token CSS variable using code as it comes out of Figma:
```css
--bcds-typography-regular-body: 400 1rem/1.688rem 'BC Sans';
```

If I were to use that CSS variable along with the CSS `@font-face` code in this package as it is today, my end users would not see the BC Sans font as intended.

Any Figma user designing with BC Sans will have this issue, regardless of whether they choose to use our design tokens or not. Here's an example new Figma file that doesn't use the design tokens, which I've built using the web interface. I've set the font face to BC Sans using Figma's font agent on my Mac:

<img width="1728" alt="Figma file showing BC Sans usage" src="https://github.com/bcgov/bc-sans/assets/25143706/8ed396b4-a593-4580-af5e-e981c81c5171">

To improve the designer and developer experience of using this package along with Figma, I propose that we should add the correct font name to the CSS declarations as I've done in d13e52f47d478dafb491a85623321dc0fc67daec. I don't think we can make the correction in place, because many apps use this package and have code written to reference the `BCSans` name. Even fixing it in place with a major version bump will cause a lot of pain. I think any change like this would need to be additive.

I recognize that this will mean more code shipped to the end user. However, I feel the benefit in terms of designer and developer experience are worth the extra 1.2K. Figma has been increasing in popularity to the point where it's the [most popular UI prototyping software](https://uxtools.co/survey/2022/ui-design/#ui-design-tools-graph), and it has been requested by our design community for years. Without this change, any future designer/developer teams using Figma to generate code in our ecosystem would also need to be aware of this bug, manually updating their code. It's also not easy for employees on Gov-provisioned laptops to notice that there is a problem with Figma's generated code - assuming they have the BC Sans font installed, the reference to `BC Sans` from Figma's code will work with their system fonts, and the problem might make it to the end user.

Please let me know your thoughts, @ShawnTurple , @mhaswell-bcgov .