### PR TITLE
GitHub Actions workflow to publish package to GitHub Packages

### DIFF
--- a/.github/workflows/publish-github-package.yaml
+++ b/.github/workflows/publish-github-package.yaml
@@ -1,0 +1,32 @@
+name: Publish package to GitHub Packages
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-gpr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://npm.pkg.github.com
+          scope: "@bcgov"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish package
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/bc-sans",
-  "version": "2.0.0",
-  "lockfileVersion": 2,
+  "version": "2.1.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/bc-sans",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "SIL"
     }
   }


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to publish `@bcgov/bc-sans` to GitHub Packages. This work is in support of #20.

Repos like [bcgov/aps-devops](https://github.com/bcgov/aps-devops) and [bcgov/design-system](https://github.com/bcgov/design-system) are dependent on other packages from the `@bcgov` scope. Historically, these have been hosted on npm, but teams are moving to publishing on GitHub Packages as well.

Currently, there's no elegant way to say "Install @bcgov/some-package from GitHub Packages, but install @bcgov/bc-sans from npm," because scoping for an organization in a `.npmrc` config can only point to a single package registry:

```
# Example .npmrc configuration

# This points all your @bcgov scoped packages to the versions hosted on GitHub:
@bcgov:registry=https://npm.pkg.github.com

# This alternate/conflicting rule points all your @bcgov scoped packages to npm: 
@bcgov:registry=https://registry.npmjs.org

# There's no way to do this:
@bcgov/some-package:registry=https://npm.pkg.github.com
@bcgov/bc-sans:registry=https://registry.npmjs.org
```

The trigger for this action is the addition of a release version, which this repo doesn't currently use. My intent after this is merged is to go back and add releases for all the versions currently hosted on npm: https://www.npmjs.com/package/@bcgov/bc-sans?activeTab=versions

- 1.0.0
- 1.0.1
- 2.0.0
- 2.0.1

There's one additional commit in here, 6981fe3140df98bb717359f2912681b26f14c46c, which updates the `package-lock.json` that wasn't bumped last time this package was updated.