### PR TITLE
Publish workflow runs on demand

### DIFF
--- a/.github/workflows/publish-github-package.yaml
+++ b/.github/workflows/publish-github-package.yaml
@@ -3,6 +3,7 @@ name: Publish package to GitHub Packages
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-github-package.yaml
+++ b/.github/workflows/publish-github-package.yaml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/publish-github-package.yaml
+++ b/.github/workflows/publish-github-package.yaml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag or SHA) to publish from"
+        required: true
 
 permissions:
   contents: read
@@ -16,6 +20,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
This PR updates the publish workflow to add a `workflow_dispatch` trigger (3982158ebc83ec8a127ae358860670b29941287b) and to pin the third party dependency actions to the latest available versions (662cc6c810e7328db7c891e5adc369d65fac786c).

The `workflow_dispatch` will be necessary to publish a GitHub Package release for an already-published release that didn't fire, [v1.0.0](https://github.com/bcgov/bc-sans/releases/tag/v1.0.0).