### PR TITLE
fix: set font-display: swap

### DIFF
--- a/css/BCSans.css
+++ b/css/BCSans.css
@@ -1,4 +1,5 @@
 @font-face {
+  font-display: swap;
   font-family: "BCSans";
   font-style: normal;
   font-weight: 400;
@@ -7,6 +8,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BCSans";
   font-style: italic;
   font-weight: 400;
@@ -15,6 +17,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BCSans";
   font-style: normal;
   font-weight: 700;
@@ -23,6 +26,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BCSans";
   font-style: italic;
   font-weight: 700;
@@ -31,6 +35,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BCSans";
   font-style: normal;
   font-weight: 300;
@@ -39,6 +44,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BCSans";
   font-style: italic;
   font-weight: 300;

--- a/css/BC_Sans.css
+++ b/css/BC_Sans.css
@@ -1,4 +1,5 @@
 @font-face {
+  font-display: swap;
   font-family: "BC Sans";
   font-style: normal;
   font-weight: 400;
@@ -7,6 +8,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BC Sans";
   font-style: italic;
   font-weight: 400;
@@ -15,6 +17,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BC Sans";
   font-style: normal;
   font-weight: 700;
@@ -23,6 +26,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BC Sans";
   font-style: italic;
   font-weight: 700;
@@ -31,6 +35,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BC Sans";
   font-style: normal;
   font-weight: 300;
@@ -39,6 +44,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: "BC Sans";
   font-style: italic;
   font-weight: 300;


### PR DESCRIPTION
Ensures text is visible even if font is not yet loaded. 

This might produce some layout shifts, but ultimately I think this is more accessible particularly on slower networks.

Originally from https://github.com/bcgov/bc-sans/pull/9